### PR TITLE
FIX 잘못된 어노테이션으로 인한 오류 수정

### DIFF
--- a/src/main/java/com/example/charging_life/member/MemberController.java
+++ b/src/main/java/com/example/charging_life/member/MemberController.java
@@ -83,7 +83,7 @@ public class MemberController {
     @GetMapping("member/station/{statId}")
     public ResponseEntity<Boolean> checkFavorite(
             @RequestHeader(name = "Authorization") String accessToken,
-            @RequestParam String statId) {
+            @PathVariable String statId) {
         Member member = findMemberByToken(accessToken);
         return ResponseEntity.ok(memberService.checkFavorite(member,statId));
     }


### PR DESCRIPTION
statId를 쿼리 파라미터로 받아 오류가 발생했다. URI 변수값을 가져오도록 변경했다.